### PR TITLE
fix: remove bottle :unneeded

### DIFF
--- a/Formula/nfpm.rb
+++ b/Formula/nfpm.rb
@@ -7,7 +7,6 @@ class Nfpm < Formula
   homepage "https://nfpm.goreleaser.com"
   version "2.7.1"
   license "MIT"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.arm?


### PR DESCRIPTION
This PR fixes a warning issued by Homebrew when users use goreleaser/homebrew-tap.

> Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the goreleaser/homebrew-tap tap (not Homebrew/brew or Homebrew/core):