### PR TITLE
Fix brew install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 Homebrew Formulae to @goreleaser binaries, powered by @goreleaser
 
 ```sh
-brew install goreleaser/tap/goreleaser
+brew install --cask goreleaser/tap/goreleaser
 ```


### PR DESCRIPTION
Brew install command was still showing instructions for the formula not the cask. 